### PR TITLE
ADD: BaseCamera helper methods

### DIFF
--- a/SofaKernel/framework/sofa/defaulttype/CMakeLists.txt
+++ b/SofaKernel/framework/sofa/defaulttype/CMakeLists.txt
@@ -30,6 +30,7 @@ set(HEADER_FILES
     defaulttype.h
     init.h
     Color.h
+    Ray.h
 )
 
 if(EIGEN3_FOUND OR Eigen3_FOUND)

--- a/SofaKernel/framework/sofa/defaulttype/Ray.h
+++ b/SofaKernel/framework/sofa/defaulttype/Ray.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "Vec.h"
+
+namespace sofa {
+namespace defaulttype {
+
+class Ray
+{
+public:
+    Ray(const Vec3& origin = Vec3(0,0,0), const Vec3& direction = Vec3(0,0,0))
+    {
+        m_origin = origin;
+        m_direction = direction.normalized();
+    }
+
+    const Vec3& origin() const { return m_origin; }
+    const Vec3& direction() const { return m_direction; }
+
+    Vec3 getPoint(double z) const
+    {
+        return m_origin + (m_direction.normalized() * z);
+    }
+
+    void setOrigin(const Vec3& origin) { m_origin = origin; }
+    void setDirection(const Vec3& direction) { m_direction = direction.normalized(); }
+
+private:
+    Vec3 m_origin;
+    Vec3 m_direction;
+};
+} // namespace defaulttype
+} // namespace sofa

--- a/SofaKernel/modules/SofaBaseVisual/BaseCamera.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/BaseCamera.cpp
@@ -323,6 +323,8 @@ BaseCamera::Vec3 BaseCamera::screenToWorldCoordinates(int x, int y)
     const sofa::core::visual::VisualParams* vp = sofa::core::visual::VisualParams::defaultInstance();
 
     const core::visual::VisualParams::Viewport viewport = vp->viewport();
+    if (viewport.empty() || !vp->drawTool())
+        return Vec3(0,0,0);
 
     double winX = (double)x;
     double winY = (double)viewport[3] - (double)y;
@@ -334,13 +336,33 @@ BaseCamera::Vec3 BaseCamera::screenToWorldCoordinates(int x, int y)
     this->getModelViewMatrix(modelview);
     this->getProjectionMatrix(projection);
 
+
     float fwinZ = 0.0;
     vp->drawTool()->readPixels(x, int(winY), 1, 1, nullptr, &fwinZ);
 
     double winZ = (double)fwinZ;
     glhUnProjectf<double>(winX, winY, winZ, modelview, projection, viewport, pos);
-
     return Vec3(pos[0], pos[1], pos[2]);
+}
+
+BaseCamera::Vec2 BaseCamera::worldToScreenCoordinates(const BaseCamera::Vec3& pos)
+{
+    const sofa::core::visual::VisualParams* vp = sofa::core::visual::VisualParams::defaultInstance();
+
+    const core::visual::VisualParams::Viewport viewport = vp->viewport();
+    sofa::defaulttype::Vector4 clipSpacePos = {pos.x(), pos.y(), pos.z(), 1.0};
+    sofa::defaulttype::Mat4x4d modelview;
+    sofa::defaulttype::Mat4x4d projection;
+
+    this->getModelViewMatrix(modelview.ptr());
+    this->getProjectionMatrix(projection.ptr());
+
+    clipSpacePos = projection * (modelview * clipSpacePos);
+    if (clipSpacePos.w() == 0.0)
+        clipSpacePos.w() = 1.0;
+    sofa::defaulttype::Vec3 ndcSpacePos = sofa::defaulttype::Vec3(clipSpacePos.x(),clipSpacePos.y(), clipSpacePos.z()) * clipSpacePos.w();
+    Vec2 screenCoord = Vec2((ndcSpacePos.x() + 1.0) / 2.0 * viewport[2], (ndcSpacePos.y() + 1.0) / 2.0 * viewport[3]);
+    return screenCoord + Vec2(viewport[0], viewport[1]);
 }
 
 void BaseCamera::getModelViewMatrix(double mat[16])
@@ -544,6 +566,86 @@ void BaseCamera::rotateWorldAroundPoint(Quat &rotation, const Vec3 &point, Quat 
 
     updateOutputData();
 }
+
+
+
+
+
+BaseCamera::Vec3 BaseCamera::screenToViewportPoint(const BaseCamera::Vec3& p) const
+{
+    if (p_widthViewport == 0 || p_heightViewport == 0)
+        return Vec3(0, 0, p.z());
+    return Vec3(p.x() / this->p_widthViewport.getValue(),
+                p.y() / this->p_heightViewport.getValue(),
+                p.z());
+}
+BaseCamera::Vec3 BaseCamera::screenToWorldPoint(const BaseCamera::Vec3& p)
+{
+    Vec3 vP = screenToViewportPoint(p);
+    return viewportToWorldPoint(vP);
+}
+
+BaseCamera::Vec3 BaseCamera::viewportToScreenPoint(const BaseCamera::Vec3& p) const
+{
+    return Vec3(p.x() * p_widthViewport.getValue(), p.y() * p_heightViewport.getValue(), p.z());
+}
+BaseCamera::Vec3 BaseCamera::viewportToWorldPoint(const BaseCamera::Vec3& p)
+{
+    Vec3 nsPosition = Vec3(p.x() * 2.0 - 1.0, (1.0 - p.y()) * 2.0 - 1.0, p.z() * 2.0 - 1.0);
+
+    Mat4 glP, glM;
+    getOpenGLProjectionMatrix(glP.ptr());
+    getOpenGLModelViewMatrix(glM.ptr());
+    Vec4 vsPosition = glP.inverted() * Vec4(nsPosition, 1.0);
+    vsPosition /= vsPosition.w();
+
+    Vec4 v = (glM * vsPosition);
+
+    return Vec3(v[0],v[1],v[2]);
+}
+
+BaseCamera::Vec3 BaseCamera::worldToScreenPoint(const BaseCamera::Vec3& p)
+{
+    Mat4 glP, glM;
+    getOpenGLProjectionMatrix(glP.ptr());
+    getOpenGLModelViewMatrix(glM.ptr());
+
+    Vec4 nsPosition = (glP * glM * Vec4(p, 1.0));
+    nsPosition /= nsPosition.w();
+
+    return Vec3((nsPosition.x() * 0.5 + 0.5) * p_widthViewport.getValue() + 0.5,
+                p_heightViewport.getValue() - (nsPosition.y() * 0.5 + 0.5) * p_heightViewport.getValue() + 0.5,
+                (nsPosition.z() * 0.5 + 0.5));
+}
+BaseCamera::Vec3 BaseCamera::worldToViewportPoint(const BaseCamera::Vec3& p)
+{
+    Mat4 glP, glM;
+    getOpenGLProjectionMatrix(glP.ptr());
+    getOpenGLModelViewMatrix(glM.ptr());
+
+    Vec4 nsPosition = (glP * glM * Vec4(p, 1.0));
+    nsPosition /= nsPosition.w();
+
+    return Vec3((nsPosition.x() * 0.5 + 0.5),
+                ((1.0 - nsPosition.y()) * 0.5 - 0.5),
+                nsPosition.z() * 0.5 + 0.5);
+}
+
+BaseCamera::Ray BaseCamera::viewportPointToRay(const BaseCamera::Vec3& p)
+{
+    return Ray(this->p_position.getValue(), (this->p_position.getValue() - viewportToWorldPoint(p)));
+}
+BaseCamera::Ray BaseCamera::screenPointToRay(const BaseCamera::Vec3& p)
+{
+    return Ray(this->p_position.getValue(), (this->p_position.getValue() - screenToWorldPoint(p)));
+}
+
+BaseCamera::Ray BaseCamera::toRay() const
+{
+    return Ray(this->p_position.getValue(), this->p_lookAt.getValue());
+}
+
+
 
 void BaseCamera::computeZ()
 {

--- a/SofaKernel/modules/SofaBaseVisual/BaseCamera.cpp
+++ b/SofaKernel/modules/SofaBaseVisual/BaseCamera.cpp
@@ -596,6 +596,7 @@ BaseCamera::Vec3 BaseCamera::viewportToWorldPoint(const BaseCamera::Vec3& p)
     Mat4 glP, glM;
     getOpenGLProjectionMatrix(glP.ptr());
     getOpenGLModelViewMatrix(glM.ptr());
+
     Vec4 vsPosition = glP.inverted() * Vec4(nsPosition, 1.0);
     vsPosition /= vsPosition.w();
 
@@ -633,11 +634,11 @@ BaseCamera::Vec3 BaseCamera::worldToViewportPoint(const BaseCamera::Vec3& p)
 
 BaseCamera::Ray BaseCamera::viewportPointToRay(const BaseCamera::Vec3& p)
 {
-    return Ray(this->p_position.getValue(), (this->p_position.getValue() - viewportToWorldPoint(p)));
+    return Ray(this->p_position.getValue(), (viewportToWorldPoint(p) - this->p_position.getValue()));
 }
 BaseCamera::Ray BaseCamera::screenPointToRay(const BaseCamera::Vec3& p)
 {
-    return Ray(this->p_position.getValue(), (this->p_position.getValue() - screenToWorldPoint(p)));
+    return Ray(this->p_position.getValue(), (screenToWorldPoint(p) - this->p_position.getValue()));
 }
 
 BaseCamera::Ray BaseCamera::toRay() const

--- a/SofaKernel/modules/SofaBaseVisual/BaseCamera.h
+++ b/SofaKernel/modules/SofaBaseVisual/BaseCamera.h
@@ -25,6 +25,7 @@
 
 #include <sofa/core/objectmodel/BaseObject.h>
 #include <sofa/defaulttype/Vec.h>
+#include <sofa/defaulttype/Ray.h>
 #include <sofa/defaulttype/Mat.h>
 #include <sofa/helper/Quater.h>
 
@@ -49,7 +50,10 @@ public:
     SOFA_CLASS(BaseCamera, core::objectmodel::BaseObject);
 
     typedef sofa::core::visual::VisualParams::CameraType CameraType;
+    typedef defaulttype::Ray Ray;
+    typedef defaulttype::Vector4 Vec4;
     typedef defaulttype::Vector3 Vec3;
+    typedef defaulttype::Vector2 Vec2;
     typedef defaulttype::Matrix3 Mat3;
     typedef defaulttype::Matrix4 Mat4;
     typedef defaulttype::Quat Quat;
@@ -121,11 +125,27 @@ public:
     void rotateCameraAroundPoint( Quat& rotation, const Vec3& point);
     virtual void rotateWorldAroundPoint( Quat& rotation, const Vec3& point, Quat orientationCam);
 
+    Vec3 screenToViewportPoint(const Vec3& p) const;
+    Vec3 screenToWorldPoint(const Vec3& p);
+
+    Vec3 viewportToScreenPoint(const Vec3& p) const;
+    Vec3 viewportToWorldPoint(const Vec3& p);
+
+    Vec3 worldToScreenPoint(const Vec3& p);
+    Vec3 worldToViewportPoint(const Vec3& p);
+
+    Ray viewportPointToRay(const Vec3&p);
+    Ray screenPointToRay(const Vec3&p);
+
+    Ray toRay() const;
+
+
     Vec3 cameraToWorldCoordinates(const Vec3& p);
     Vec3 worldToCameraCoordinates(const Vec3& p);
     Vec3 cameraToWorldTransform(const Vec3& v);
     Vec3 worldToCameraTransform(const Vec3& v);
     Vec3 screenToWorldCoordinates(int x, int y);
+    Vec2 worldToScreenCoordinates(const Vec3& p);
 
     void fitSphere(const Vec3& center, SReal radius);
     void fitBoundingBox(const Vec3& min,const Vec3& max);


### PR DESCRIPTION
- New Ray class in defaulttype
- BaseCamera::screenToViewportPoint
- BaseCamera::screenToWorldPoint
- BaseCamera::worldToScreenPoint
- BaseCamera::worldToViewportPoint
- BaseCamera::viewportToWorldPoint
- BaseCamera::viewportToScreenPoint
- BaseCamera::viewportPointToRay
- BaseCamera::screenPointToRay
- BaseCamera::toRay

Tested **rudimentarily** by creating an arbitrary 2D point, and converting back n forth. seems to work, but can't tell for sure with Z... (there seem to be an inversion of direction, maybe from the OpenGL 180° rotation around X, when converting to world coord, and I get huge z when converting back. example of test below):

```
viewport: 635x621
glProjection / glModelView: defaults from runSofa2's BaseCamera
input point: 142 142
toViewportCoord: 0.223622 0.228663 1
toWorldCoord: -0.0047776 0.00458704 -1.02025
back to viewportCoord:  0.223622 -0.271337 2492.75
back to screenCoord:  142 -168.5 2492.75
```

I wanted to add a unit test in SofaBaseVisual, but I don't know how to mock the glProjection / glModelView that are retrieved in getOpenGLProjection / getOpenGLModelView called within my added methods... I'll look into it on monday ;)



______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
