### PR TITLE
[ARTrack] FIX Windows C++17 error

### DIFF
--- a/applications/plugins/ARTrack/extlibs/ARTrackLib/mainTracker.cpp
+++ b/applications/plugins/ARTrack/extlibs/ARTrackLib/mainTracker.cpp
@@ -19,7 +19,6 @@
 
 #include <iostream>
 
-using namespace std;
 #ifndef _WIN32
 #define OS_UNIX  // for Unix (Linux, Irix)
 #else


### PR DESCRIPTION
error C2872: 'byte': ambiguous symbol






______________________________________________________
<!--- Please leave this at the end of your message -->
This PR: 
- [ ] builds with SUCCESS for all platforms on the CI.
- [ ] does not generate new warnings.
- [ ] does not generate new unit test failures.
- [ ] does not generate new scene test failures.
- [ ] does not break API compatibility.
- [ ] is more than 1 week old (or has fast-merge label).

**Reviewers will merge only if all these checks are true.**
